### PR TITLE
Add Web Bluetooth connection context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@eslint/js": "^9.29.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/web-bluetooth": "^0.0.21",
         "@vitejs/plugin-react-swc": "^3.10.2",
         "eslint": "^9.29.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -1266,6 +1267,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.35.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@eslint/js": "^9.29.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/web-bluetooth": "^0.0.21",
     "@vitejs/plugin-react-swc": "^3.10.2",
     "eslint": "^9.29.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,18 @@
-import { useState } from 'react'
 import Main from './com/Main'
+import { DeviceProvider } from './com/DeviceContext'
 
 import './App.css'
 
 
 function App() {
-  const [count, setCount] = useState(0)
-  
   return <>
     <header>
       <h1>Bluetooth Web Dashboard</h1>
     </header>
 
-    <Main />
+    <DeviceProvider>
+      <Main />
+    </DeviceProvider>
 
     <footer>
       <p>fingerskier</p>

--- a/src/com/DeviceContext.tsx
+++ b/src/com/DeviceContext.tsx
@@ -1,0 +1,52 @@
+import { createContext, useContext, useState } from 'react'
+import type { ReactNode } from 'react'
+
+export type ServiceInfo = {
+  uuid: string
+  characteristics: string[]
+}
+
+interface DeviceState {
+  device: BluetoothDevice | null
+  services: ServiceInfo[]
+  connect: () => Promise<void>
+}
+
+const DeviceContext = createContext<DeviceState | undefined>(undefined)
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useDevice() {
+  const ctx = useContext(DeviceContext)
+  if (!ctx) throw new Error('useDevice must be used within DeviceProvider')
+  return ctx
+}
+
+export function DeviceProvider({ children }: { children: ReactNode }) {
+  const [device, setDevice] = useState<BluetoothDevice | null>(null)
+  const [services, setServices] = useState<ServiceInfo[]>([])
+
+  async function connect() {
+    const dev = await navigator.bluetooth.requestDevice({ acceptAllDevices: true })
+    const server = await dev.gatt?.connect()
+    const serviceInfos: ServiceInfo[] = []
+    try {
+      const primaryServices = await server?.getPrimaryServices()
+      if (primaryServices) {
+        for (const srv of primaryServices) {
+          const chars = await srv.getCharacteristics()
+          serviceInfos.push({ uuid: srv.uuid, characteristics: chars.map(c => c.uuid) })
+        }
+      }
+    } catch (err) {
+      console.error('Failed to read services', err)
+    }
+    setDevice(dev)
+    setServices(serviceInfos)
+  }
+
+  return (
+    <DeviceContext.Provider value={{ device, services, connect }}>
+      {children}
+    </DeviceContext.Provider>
+  )
+}

--- a/src/com/Main.tsx
+++ b/src/com/Main.tsx
@@ -1,15 +1,36 @@
-import React from 'react'
-import {StateMachine, State} from 'ygdrassil'
+import { StateMachine, State } from 'ygdrassil'
 import Navigator from './Navigator'
+import { useDevice } from './DeviceContext'
 
 
 export default function Main() {
+  const { device, services, connect } = useDevice()
   return <div>
     <StateMachine name="wbt" initial="devices">
       <Navigator />
 
       <State name="devices">
-        <h2>Devices</h2>
+        <>
+          <h2>Devices</h2>
+          <button onClick={connect}>Connect</button>
+          {device && (
+            <div>
+              <h3>{device.name ?? device.id}</h3>
+              <ul>
+                {services.map(s => (
+                  <li key={s.uuid}>
+                    <strong>{s.uuid}</strong>
+                    <ul>
+                      {s.characteristics.map(c => (
+                        <li key={c}>{c}</li>
+                      ))}
+                    </ul>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
       </State>
 
       <State name="details">

--- a/src/com/Navigator.tsx
+++ b/src/com/Navigator.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {StateButton} from 'ygdrassil'
 
 


### PR DESCRIPTION
## Summary
- add `DeviceContext` for tracking connected Bluetooth devices
- wrap app in `DeviceProvider`
- show a **Connect** button on the Devices tab and list services/characteristics
- cleanup unused imports
- install `@types/web-bluetooth`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867db856c2c8327871b0ee12a78c613